### PR TITLE
correct error in lint-staged script

### DIFF
--- a/content/blog/using-eslint-and-prettier-in-a-typescript-project/index.md
+++ b/content/blog/using-eslint-and-prettier-in-a-typescript-project/index.md
@@ -205,7 +205,7 @@ To configure `lint-staged` and `husky`, add the following configuration to the `
   },
   "lint-staged": {
       "*.{js,ts,tsx}": [
-          "eslint . --fix",
+          "eslint --fix",
           "git add"
       ]
   }


### PR DESCRIPTION
Makes sure ESLint only runs for staged files. The dot made it run for a larger subset of files.

Thanks for a great post!